### PR TITLE
time_window: include the value at the start of the window (and fix tests)

### DIFF
--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -24,9 +24,9 @@ class TestDelayPersistent(object):
         return []
     
     @pytest.fixture
-    def sem(self, event_loop):
+    def sem(self):
         """A semaphore released whenever the callback is called."""
-        return asyncio.Semaphore(0, loop=event_loop)
+        return asyncio.Semaphore(0)
     
     @pytest.fixture
     def dv(self, v, dt, log, sem, event_loop):
@@ -87,7 +87,7 @@ class TestDelayPersistent(object):
         # Changing the delay after a value change has occurred should push that
         # change further into the past, but only relative to its original start
         # time
-        await asyncio.sleep(0.05, loop=event_loop)
+        await asyncio.sleep(0.05)
         dt.value = 0.2
         
         await sem.acquire()
@@ -102,7 +102,7 @@ class TestDelayPersistent(object):
         
         # Changing the delay after a value change has occurred should push that
         # delay closer
-        await asyncio.sleep(0.025, loop=event_loop)
+        await asyncio.sleep(0.025)
         dt.value = 0.05
         
         await sem.acquire()
@@ -117,7 +117,7 @@ class TestDelayPersistent(object):
         
         # Changing the delay such that a still-delayed value should have been
         # output already should cause that value to be output immediately
-        await asyncio.sleep(0.05, loop=event_loop)
+        await asyncio.sleep(0.05)
         dt.value = 0.01
         
         assert len(log) == 1
@@ -128,14 +128,14 @@ class TestDelayPersistent(object):
 class TestDelayInstantaneous(object):
 
     @pytest.mark.asyncio
-    async def test_instantaneous(self, event_loop):
+    async def test_instantaneous(self):
         value = Value()
         
-        delayed_value = delay(value, 0.1, loop=event_loop)
+        delayed_value = delay(value, 0.1)
         assert delayed_value.value is NoValue
         
         # Monitor changes
-        evt = asyncio.Event(loop=event_loop)
+        evt = asyncio.Event()
         m = Mock(side_effect=lambda *_: evt.set())
         delayed_value.on_value_changed(m)
         

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -7,15 +7,15 @@ from mock import Mock
 from yarp import NoValue, Value, rate_limit
 
 @pytest.mark.asyncio
-async def test_rate_limit_persistent(event_loop):
+async def test_rate_limit_persistent():
     v = Value(1)
     
     # Initial value should be passed through
-    rlv = rate_limit(v, 0.1, event_loop)
+    rlv = rate_limit(v, 0.1)
     assert rlv.value == 1
     
     log = []
-    sem = asyncio.Semaphore(0, loop=event_loop)
+    sem = asyncio.Semaphore(0)
     def on_change(new_value):
         log.append(new_value)
         sem.release()
@@ -35,7 +35,7 @@ async def test_rate_limit_persistent(event_loop):
     assert log[-1] == 2
     
     # After a suitable delay, the next change should come through immediately
-    await asyncio.sleep(0.15, loop=event_loop)
+    await asyncio.sleep(0.15)
     v.value = 3
     assert rlv.value == 3
     assert len(log) == 2
@@ -57,15 +57,15 @@ async def test_rate_limit_persistent(event_loop):
     assert log[-1] == 6
 
 @pytest.mark.asyncio
-async def test_rate_limit_instantaneous(event_loop):
+async def test_rate_limit_instantaneous():
     v = Value()
     
     # No initial value to speak of
-    rlv = rate_limit(v, 0.1, event_loop)
+    rlv = rate_limit(v, 0.1)
     assert rlv.value is NoValue
     
     log = []
-    sem = asyncio.Semaphore(0, loop=event_loop)
+    sem = asyncio.Semaphore(0)
     def on_change(new_value):
         log.append(new_value)
         sem.release()
@@ -92,7 +92,7 @@ async def test_rate_limit_instantaneous(event_loop):
     assert log[-1] == 2
     
     # After a suitable delay, the next change should come through immediately
-    await asyncio.sleep(0.15, loop=event_loop)
+    await asyncio.sleep(0.15)
     v.set_instantaneous_value(3)
     assert rlv.value is NoValue
     assert len(log) == 3
@@ -114,15 +114,15 @@ async def test_rate_limit_instantaneous(event_loop):
     assert log[-1] == 6
 
 @pytest.mark.asyncio
-async def test_rate_limit_min_interval_change(event_loop):
+async def test_rate_limit_min_interval_change():
     v = Value(123)
     mi = Value(0.1)
     
     start = time.time()
-    rlv = rate_limit(v, mi, event_loop)
+    rlv = rate_limit(v, mi)
     
     log = []
-    sem = asyncio.Semaphore(0, loop=event_loop)
+    sem = asyncio.Semaphore(0)
     def on_change(new_value):
         log.append(new_value)
         sem.release()
@@ -154,7 +154,7 @@ async def test_rate_limit_min_interval_change(event_loop):
     # already ellapsed and the value should emmerge immediately
     v.value = 4321
     assert rlv.value == 1234
-    await asyncio.sleep(0.05, loop=event_loop)
+    await asyncio.sleep(0.05)
     assert rlv.value == 1234
     mi.value = 0.025
     assert rlv.value == 4321
@@ -164,7 +164,7 @@ async def test_rate_limit_min_interval_change(event_loop):
     
     # If we ensure blocking is not occurring, changing the time shouldn't cause
     # problems
-    await asyncio.sleep(0.05, loop=event_loop)
+    await asyncio.sleep(0.05)
     mi.value = 0.1
     v.value = 12345
     assert rlv.value == 12345

--- a/tests/test_time_and_date.py
+++ b/tests/test_time_and_date.py
@@ -20,9 +20,9 @@ class TestNow(object):
         return []
     
     @pytest.fixture
-    def sem(self, event_loop):
+    def sem(self):
         """A semaphore released whenever the callback is called."""
-        return asyncio.Semaphore(0, loop=event_loop)
+        return asyncio.Semaphore(0)
     
     @pytest.fixture
     def t(self, interval, log, sem, event_loop):
@@ -42,7 +42,7 @@ class TestNow(object):
         assert abs((t.value - _datetime.datetime.now()).total_seconds()) < 0.05
     
     @pytest.mark.asyncio
-    async def test_regular_interval(self, t, sem, log, event_loop):
+    async def test_regular_interval(self, t, sem, log):
         await sem.acquire()
         await sem.acquire()
         await sem.acquire()
@@ -55,12 +55,12 @@ class TestNow(object):
         assert all(0.05 < t < 0.15 for t in t_deltas)
     
     @pytest.mark.asyncio
-    async def test_change_interval(self, t, interval, sem, log, event_loop):
+    async def test_change_interval(self, t, interval, sem, log):
         await sem.acquire()
         await sem.acquire()
         assert len(log) == 2
         
-        await asyncio.sleep(0.05, loop=event_loop)
+        await asyncio.sleep(0.05)
         interval.value = 0.2
         
         await sem.acquire()

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -59,11 +59,11 @@ class TestTimeWindow(object):
         return []
     
     @pytest.fixture
-    def sem(self, event_loop):
+    def sem(self):
         """
         A semaphore released whenever the 'win' value changes.
         """
-        return asyncio.Semaphore(0, loop=event_loop)
+        return asyncio.Semaphore(0)
     
     @pytest.fixture
     def win(self, v, dv, sem, log, event_loop):
@@ -94,7 +94,7 @@ class TestTimeWindow(object):
     
     
     @pytest.mark.asyncio
-    async def test_initial_value(self, v, dv, win, sem, log, event_loop):
+    async def test_initial_value(self, v, dv, win, sem, log):
         start = time.time()
         
         # Should start with the current value
@@ -108,7 +108,7 @@ class TestTimeWindow(object):
         assert log[-1][1] == []
     
     @pytest.mark.asyncio
-    async def test_adding_values(self, v, dv, win, sem, log, remove_initial_win_value, event_loop):
+    async def test_adding_values(self, v, dv, win, sem, log, remove_initial_win_value):
         # Adding values should appear immediately and disappear later
         start = time.time()
         v.value = 2
@@ -127,13 +127,13 @@ class TestTimeWindow(object):
         assert log[-1][1] == []
         
     @pytest.mark.asyncio
-    async def test_adding_values_spaced(self, v, dv, win, sem, log, remove_initial_win_value, event_loop):
+    async def test_adding_values_spaced(self, v, dv, win, sem, log, remove_initial_win_value):
         # Adding values spaced appart should disappear spaced appart
         first = time.time()
         v.value = 4
         assert win.value == [4]
         assert len(log) == 1
-        await asyncio.sleep(0.05, loop=event_loop)
+        await asyncio.sleep(0.05)
         
         second = time.time()
         v.value = 5
@@ -153,7 +153,7 @@ class TestTimeWindow(object):
         assert log[-1][1] == []
     
     @pytest.mark.asyncio
-    async def test_increase_timeout(self, v, dv, win, sem, log, remove_initial_win_value, event_loop):
+    async def test_increase_timeout(self, v, dv, win, sem, log, remove_initial_win_value):
         # Insert a couple of values
         start = time.time()
         v.value = 6
@@ -177,7 +177,7 @@ class TestTimeWindow(object):
         assert win.value == []
     
     @pytest.mark.asyncio
-    async def test_decrease_timeout(self, v, dv, win, sem, log, remove_initial_win_value, event_loop):
+    async def test_decrease_timeout(self, v, dv, win, sem, log, remove_initial_win_value):
         # Insert a couple more values
         start = time.time()
         v.value = 8
@@ -201,7 +201,7 @@ class TestTimeWindow(object):
         assert win.value == []
     
     @pytest.mark.asyncio
-    async def test_decrease_timeout_lots(self, v, dv, win, sem, log, remove_initial_win_value, event_loop):
+    async def test_decrease_timeout_lots(self, v, dv, win, sem, log, remove_initial_win_value):
         # Insert a few more values
         start = time.time()
         v.value = 10
@@ -213,7 +213,7 @@ class TestTimeWindow(object):
         assert log[-2][1] == [10]
         assert log[-1][1] == [10, 11]
         
-        await asyncio.sleep(0.05, loop=event_loop)
+        await asyncio.sleep(0.05)
         assert win.value == [10, 11]
         
         # Decreasing the timeout so that the previously inserted items should have

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -80,18 +80,6 @@ class TestTimeWindow(object):
         
         return win
     
-    @pytest.fixture
-    def remove_initial_win_value(self, win, dv, sem, log, event_loop):
-        """
-        A bodge to make tests quicker: Removes the initial value from the window
-        by zeroing out the timer temporarily.
-        """
-        old_dv = dv.value
-        dv.value = 0
-        dv.value = old_dv
-        log.clear()
-        event_loop.run_until_complete(sem.acquire())
-    
     
     @pytest.mark.asyncio
     async def test_initial_value(self, v, dv, win, sem, log):
@@ -100,44 +88,41 @@ class TestTimeWindow(object):
         # Should start with the current value
         assert win.value == [1]
         
-        # Initial value should fall out after delay
-        await sem.acquire()
-        assert win.value == []
-        assert len(log) == 1
-        assert log[-1][0] - start >= 0.1
-        assert log[-1][1] == []
+        # current value should persist after delay
+        await asyncio.sleep(0.15)
+        assert sem.locked()
     
     @pytest.mark.asyncio
-    async def test_adding_values(self, v, dv, win, sem, log, remove_initial_win_value):
+    async def test_adding_values(self, v, dv, win, sem, log):
         # Adding values should appear immediately and disappear later
         start = time.time()
         v.value = 2
         v.value = 3
-        assert win.value == [2, 3]
+        assert win.value == [1, 2, 3]
         assert len(log) == 2
-        await sem.acquire()  # Initial settings
+        await sem.acquire()
         await sem.acquire()
         await sem.acquire()  # Expirations
         await sem.acquire()
-        assert win.value == []
+        assert win.value == [3]
         assert len(log) == 4
         assert log[-2][0] - start >= 0.1
         assert log[-1][0] - start >= 0.1
-        assert log[-2][1] == [3]
-        assert log[-1][1] == []
+        assert log[-2][1] == [2, 3]
+        assert log[-1][1] == [3]
         
     @pytest.mark.asyncio
-    async def test_adding_values_spaced(self, v, dv, win, sem, log, remove_initial_win_value):
+    async def test_adding_values_spaced(self, v, dv, win, sem, log):
         # Adding values spaced appart should disappear spaced appart
         first = time.time()
         v.value = 4
-        assert win.value == [4]
+        assert win.value == [1, 4]
         assert len(log) == 1
         await asyncio.sleep(0.05)
         
         second = time.time()
         v.value = 5
-        assert win.value == [4, 5]
+        assert win.value == [1, 4, 5]
         assert len(log) == 2
         
         await sem.acquire()  # Initial settings
@@ -145,25 +130,25 @@ class TestTimeWindow(object):
         await sem.acquire()  # Expirations
         await sem.acquire()
         
-        assert win.value == []
+        assert win.value == [5]
         assert len(log) == 4
         assert log[-2][0] - first >= 0.1
         assert log[-1][0] - second >= 0.1
-        assert log[-2][1] == [5]
-        assert log[-1][1] == []
+        assert log[-2][1] == [4, 5]
+        assert log[-1][1] == [5]
     
     @pytest.mark.asyncio
-    async def test_increase_timeout(self, v, dv, win, sem, log, remove_initial_win_value):
+    async def test_increase_timeout(self, v, dv, win, sem, log):
         # Insert a couple of values
         start = time.time()
         v.value = 6
         v.value = 7
         await sem.acquire()
         await sem.acquire()
-        assert win.value == [6, 7]
+        assert win.value == [1, 6, 7]
         assert len(log) == 2
-        assert log[-2][1] == [6]
-        assert log[-1][1] == [6, 7]
+        assert log[-2][1] == [1, 6]
+        assert log[-1][1] == [1, 6, 7]
         
         # Increasing the timeout should keep the values for longer
         dv.value = 0.15
@@ -172,22 +157,22 @@ class TestTimeWindow(object):
         assert len(log) == 4
         assert log[-2][0] - start >= 0.15
         assert log[-1][0] - start >= 0.15
-        assert log[-2][1] == [7]
-        assert log[-1][1] == []
-        assert win.value == []
+        assert log[-2][1] == [6, 7]
+        assert log[-1][1] == [7]
+        assert win.value == [7]
     
     @pytest.mark.asyncio
-    async def test_decrease_timeout(self, v, dv, win, sem, log, remove_initial_win_value):
+    async def test_decrease_timeout(self, v, dv, win, sem, log):
         # Insert a couple more values
         start = time.time()
         v.value = 8
         v.value = 9
         await sem.acquire()
         await sem.acquire()
-        assert win.value == [8, 9]
+        assert win.value == [1, 8, 9]
         assert len(log) == 2
-        assert log[-2][1] == [8]
-        assert log[-1][1] == [8, 9]
+        assert log[-2][1] == [1, 8]
+        assert log[-1][1] == [1, 8, 9]
         
         # Decreasing the timeout should make the values come out earlier
         dv.value = 0.1
@@ -196,32 +181,32 @@ class TestTimeWindow(object):
         assert len(log) == 4
         assert log[-2][0] - start >= 0.1 and log[-2][0] - start < 0.15
         assert log[-1][0] - start >= 0.1 and log[-1][0] - start < 0.15
-        assert log[-2][1] == [9]
-        assert log[-1][1] == []
-        assert win.value == []
+        assert log[-2][1] == [8, 9]
+        assert log[-1][1] == [9]
+        assert win.value == [9]
     
     @pytest.mark.asyncio
-    async def test_decrease_timeout_lots(self, v, dv, win, sem, log, remove_initial_win_value):
+    async def test_decrease_timeout_lots(self, v, dv, win, sem, log):
         # Insert a few more values
         start = time.time()
         v.value = 10
         v.value = 11
         await sem.acquire()
         await sem.acquire()
-        assert win.value == [10, 11]
+        assert win.value == [1, 10, 11]
         assert len(log) == 2
-        assert log[-2][1] == [10]
-        assert log[-1][1] == [10, 11]
+        assert log[-2][1] == [1, 10]
+        assert log[-1][1] == [1, 10, 11]
         
         await asyncio.sleep(0.05)
-        assert win.value == [10, 11]
+        assert win.value == [1, 10, 11]
         
         # Decreasing the timeout so that the previously inserted items should have
         # been expired should make them come out immediately.
         dv.value = 0.05
-        assert win.value == []
+        assert win.value == [11]
         await sem.acquire()
         await sem.acquire()
         assert len(log) == 4
-        assert log[-2][1] == [11]
-        assert log[-1][1] == []
+        assert log[-2][1] == [10, 11]
+        assert log[-1][1] == [11]

--- a/yarp/temporal.py
+++ b/yarp/temporal.py
@@ -165,8 +165,6 @@ def time_window(source_value, duration, loop=None):
                                  expire_value))
         timers = [modify_timeout(t) for t in timers]
     
-    schedule_value_expiration()
-    
     return output_value
 
 def rate_limit(source_value, min_interval=0.1, loop=None):


### PR DESCRIPTION
See the commit messages for details.

It's entirely possible that I'm holding this wrong and the old version is fine, so I'll describe what I'm trying to do.

I have a boolean Value representing whether a window is open or not, and want to know if the window has been open in the last 5 minutes.

Before this change, the True value in the output gets removed 5 minutes after the window is opened, (even though it was open for some time after it was opened), and 5 minutes after the window is closed the same thing happens to the False value, so you can't answer this question with the output of time_window.

After this change, changes are removed from the output 5 minutes after the change after (i.e. when it changed from some state), so you can just look for a True value in the output of time_window to answer the question.

The original behaviour (or something close to it) makes more sense if you want to know something like "has this PIR sensed movement in the last 5 minutes" though, so it would be good to have something that works like that too, but i wasn't sure on the API:

- have the default behaviour make sense for instantaneous values (for compatibility) but add a `persistent` keyword parameter to enable the new behaviour
- same as above but the other way around -- the default behaviour makes sense for persistent values, and there's an `instantaneous` keyword parameter.
- separate names for each (using one underlying implementation since they are nearly the same)

That seems like a lot of words for a one line change, sorry!